### PR TITLE
Фикс инициализации скрипта

### DIFF
--- a/colors/colors.php
+++ b/colors/colors.php
@@ -53,11 +53,10 @@ function mm_widget_colors($fields, $default = '#ffffff', $roles = '', $templates
 			$output .=
 '
 $j("#'.$tv_id.'").css("background-image","none");
-$j("#'.$tv_id.'").after(\'<div id="colorpicker'.$tv_id.'"></div>\');
+$j("#'.$tv_id.'").after(\'<div id="colorpicker'.$tv_id.'"></div>\').queue(function() {$j("#colorpicker'.$tv_id.'").farbtastic("#'.$tv_id.'");});
 if ($j("#'.$tv_id.'").val() == ""){
 	$j("#'.$tv_id.'").val("'.$default.'");
 }
-$j("#colorpicker'.$tv_id.'").farbtastic("#'.$tv_id.'");
 $j("#colorpicker'.$tv_id.'").mouseup(function(){
 	// mark the document as dirty, or the value wont be saved
 	$j("#'.$tv_id.'").trigger("change");


### PR DESCRIPTION
Часто случалось, что скрипт применялся к контейнеру еще до того, как он был создан, и, соотвественно, возникала ошибка в виде алерта

Добавив .queue() скрипт будет инициализироваться после того, как создастся контейнер
